### PR TITLE
allow for opting out of moves

### DIFF
--- a/slack_extra/commands/__init__.py
+++ b/slack_extra/commands/__init__.py
@@ -15,6 +15,8 @@ from slack_extra.commands.channel.move import move_handler
 from slack_extra.commands.group import group_handler
 from slack_extra.commands.info import info_handler
 from slack_extra.commands.love import love_handler
+from slack_extra.commands.settings import settings_handler
+from slack_extra.commands.settings import settings_move_handler
 from slack_extra.commands.spoiler import spoiler_handler
 from slack_extra.config import config
 from slack_extra.utils.logging import send_heartbeat
@@ -134,6 +136,34 @@ COMMANDS = [
                     },
                 ],
             },
+        ],
+    },
+    {
+        "name": "settings",
+        "description": "Manage your Slack Extra settings",
+        "function": settings_handler,
+        "subcommands": [
+            {
+                "name": "move",
+                "description": "Change your move settings",
+                "function": settings_move_handler,
+                "parameters": [
+                    {
+                        "name": "move_type",
+                        "type": "choice",
+                        "choices": ["manual", "auto"],
+                        "description": "Move type to configure",
+                        "required": True,
+                    },
+                    {
+                        "name": "state",
+                        "type": "choice",
+                        "choices": ["on", "off"],
+                        "description": "Turn this move type on or off",
+                        "required": True,
+                    },
+                ],
+            }
         ],
     },
     {

--- a/slack_extra/commands/channel/move.py
+++ b/slack_extra/commands/channel/move.py
@@ -12,6 +12,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_extra.config import config
+from slack_extra.tables import UserSettings
 from slack_extra.utils.logging import send_heartbeat
 from slack_extra.utils.slack import is_channel_manager
 
@@ -102,6 +103,19 @@ async def move_handler(
             await send_heartbeat(f"Excluding users: `{ids}`")
             channel_members = [m for m in channel_members if m not in ids]
 
+        if channel_members:
+            opt_outs = await UserSettings.select(UserSettings.user_id).where(
+                UserSettings.user_id.is_in(channel_members),
+                UserSettings.manual_move_opt_out.eq(True),
+            )
+            opted_out_ids = {row["user_id"] for row in opt_outs}
+            if opted_out_ids:
+                await send_heartbeat(
+                    f"Skipping people who have opted out: `{sorted(opted_out_ids)}`"
+                )
+                channel_members = [m for m in channel_members if m not in opted_out_ids]
+
+        move_amount = len(channel_members)
         while len(channel_members) > 0:
             try:
                 users = channel_members[:100]
@@ -127,7 +141,7 @@ async def move_handler(
                     messages=[f"```{tb_str}```"],
                 )
 
-        await respond(f"Moved {amount} members from <#{start}> to <#{end}>")
+        await respond(f"Moved {move_amount} members from <#{start}> to <#{end}>")
         return
 
     view = (

--- a/slack_extra/commands/settings.py
+++ b/slack_extra/commands/settings.py
@@ -1,0 +1,81 @@
+from blockkit import Checkboxes
+from blockkit import Input
+from blockkit import Modal
+from blockkit import Option
+from blockkit import Section
+from slack_bolt.async_app import AsyncAck
+from slack_bolt.async_app import AsyncRespond
+from slack_sdk.web.async_client import AsyncWebClient
+
+from slack_extra.preferences import get_user_settings
+from slack_extra.preferences import set_move_enabled
+
+
+MANUAL_MOVE_OPTION = Option(
+    text="Manual moves",
+    value="manual",
+    description="Allow bulk moves to add you to channels.",
+)
+AUTO_MOVE_OPTION = Option(
+    text="Automatic moves",
+    value="auto",
+    description="Allow auto moves to add you to related channels.",
+)
+
+
+async def settings_handler(
+    ack: AsyncAck,
+    client: AsyncWebClient,
+    respond: AsyncRespond,
+    performer: str,
+    command: dict,
+):
+    await ack()
+
+    settings = await get_user_settings(performer)
+    initial_options = []
+    if settings is None or not settings.manual_move_opt_out:
+        initial_options.append(MANUAL_MOVE_OPTION)
+    if settings is None or not settings.auto_move_opt_out:
+        initial_options.append(AUTO_MOVE_OPTION)
+
+    move_checkboxes = Checkboxes(action_id="move_settings")
+    move_checkboxes.add_option(MANUAL_MOVE_OPTION)
+    move_checkboxes.add_option(AUTO_MOVE_OPTION)
+    for option in initial_options:
+        move_checkboxes.add_initial_option(option)
+
+    view = (
+        Modal()
+        .callback_id("settings")
+        .title("Settings")
+        .add_block(Section(text="Choose how Slack Extra can add you to channels."))
+        .add_block(
+            Input()
+            .label("Move")
+            .element(move_checkboxes)
+            .block_id("move_settings")
+        )
+        .submit("Save")
+        .close("Cancel")
+    ).build()
+
+    await client.views_open(trigger_id=command["trigger_id"], view=view)
+
+
+async def settings_move_handler(
+    ack: AsyncAck,
+    client: AsyncWebClient,
+    respond: AsyncRespond,
+    performer: str,
+    move_type: str,
+    state: str,
+):
+    await ack()
+
+    enabled = state == "on"
+    await set_move_enabled(performer, move_type, enabled)
+
+    move_label = "manual moves" if move_type == "manual" else "automatic moves"
+    state_label = "on" if enabled else "off"
+    await respond(f"Turned {move_label} {state_label} for you.")

--- a/slack_extra/events/member_joined_channel/move.py
+++ b/slack_extra/events/member_joined_channel/move.py
@@ -2,6 +2,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
 from slack_extra.config import config
+from slack_extra.preferences import is_move_opted_out
 from slack_extra.tables import MigrationChannel
 from slack_extra.utils.logging import send_heartbeat
 
@@ -9,6 +10,9 @@ from slack_extra.utils.logging import send_heartbeat
 async def mover_handler(body: dict, event: dict, client: AsyncWebClient):
     channel_id = event["channel"]
     user_id = event["user"]
+
+    if await is_move_opted_out(user_id, "auto"):
+        return
 
     migration_channel = await MigrationChannel.objects().where(
         MigrationChannel.channel_id == channel_id

--- a/slack_extra/piccolo_migrations/slack_extra_2026_06_21t17_59_09_692057.py
+++ b/slack_extra/piccolo_migrations/slack_extra_2026_06_21t17_59_09_692057.py
@@ -1,0 +1,132 @@
+from piccolo.apps.migrations.auto.migration_manager import MigrationManager
+from piccolo.columns.column_types import Boolean
+from piccolo.columns.column_types import Serial
+from piccolo.columns.column_types import Timestamptz
+from piccolo.columns.column_types import Varchar
+from piccolo.columns.defaults.timestamptz import TimestamptzNow
+from piccolo.columns.indexes import IndexMethod
+
+
+ID = "2026-06-21T17:59:09:692057"
+VERSION = "1.30.0"
+DESCRIPTION = ""
+
+
+async def forwards():
+    manager = MigrationManager(
+        migration_id=ID, app_name="slack_extra", description=DESCRIPTION
+    )
+
+    manager.add_table(
+        class_name="UserSettings",
+        tablename="user_settings",
+        schema=None,
+        columns=None,
+    )
+
+    manager.add_column(
+        table_class_name="UserSettings",
+        tablename="user_settings",
+        column_name="id",
+        db_column_name="id",
+        column_class_name="Serial",
+        column_class=Serial,
+        params={
+            "null": False,
+            "primary_key": True,
+            "unique": False,
+            "index": False,
+            "index_method": IndexMethod.btree,
+            "choices": None,
+            "db_column_name": None,
+            "secret": False,
+        },
+        schema=None,
+    )
+
+    manager.add_column(
+        table_class_name="UserSettings",
+        tablename="user_settings",
+        column_name="user_id",
+        db_column_name="user_id",
+        column_class_name="Varchar",
+        column_class=Varchar,
+        params={
+            "length": 20,
+            "default": "",
+            "null": False,
+            "primary_key": False,
+            "unique": True,
+            "index": True,
+            "index_method": IndexMethod.btree,
+            "choices": None,
+            "db_column_name": None,
+            "secret": False,
+        },
+        schema=None,
+    )
+
+    manager.add_column(
+        table_class_name="UserSettings",
+        tablename="user_settings",
+        column_name="manual_move_opt_out",
+        db_column_name="manual_move_opt_out",
+        column_class_name="Boolean",
+        column_class=Boolean,
+        params={
+            "default": False,
+            "null": False,
+            "primary_key": False,
+            "unique": False,
+            "index": False,
+            "index_method": IndexMethod.btree,
+            "choices": None,
+            "db_column_name": None,
+            "secret": False,
+        },
+        schema=None,
+    )
+
+    manager.add_column(
+        table_class_name="UserSettings",
+        tablename="user_settings",
+        column_name="auto_move_opt_out",
+        db_column_name="auto_move_opt_out",
+        column_class_name="Boolean",
+        column_class=Boolean,
+        params={
+            "default": False,
+            "null": False,
+            "primary_key": False,
+            "unique": False,
+            "index": False,
+            "index_method": IndexMethod.btree,
+            "choices": None,
+            "db_column_name": None,
+            "secret": False,
+        },
+        schema=None,
+    )
+
+    manager.add_column(
+        table_class_name="UserSettings",
+        tablename="user_settings",
+        column_name="created_at",
+        db_column_name="created_at",
+        column_class_name="Timestamptz",
+        column_class=Timestamptz,
+        params={
+            "default": TimestamptzNow(),
+            "null": False,
+            "primary_key": False,
+            "unique": False,
+            "index": False,
+            "index_method": IndexMethod.btree,
+            "choices": None,
+            "db_column_name": None,
+            "secret": False,
+        },
+        schema=None,
+    )
+
+    return manager

--- a/slack_extra/preferences.py
+++ b/slack_extra/preferences.py
@@ -1,0 +1,36 @@
+from slack_extra.tables import UserSettings
+
+
+async def get_user_settings(user_id: str) -> UserSettings | None:
+    return await UserSettings.objects().where(UserSettings.user_id == user_id).first()
+
+
+async def set_move_enabled(user_id: str, move_type: str, enabled: bool):
+    opt_out = not enabled
+    if move_type == "manual":
+        column = UserSettings.manual_move_opt_out
+        insert_values = {"manual_move_opt_out": opt_out}
+    elif move_type == "auto":
+        column = UserSettings.auto_move_opt_out
+        insert_values = {"auto_move_opt_out": opt_out}
+    else:
+        raise ValueError(f"unknown type?? {move_type}")
+
+    settings = await get_user_settings(user_id)
+    if settings:
+        await UserSettings.update({column: opt_out}).where(
+            UserSettings.user_id == user_id
+        )
+    else:
+        await UserSettings.insert(UserSettings(user_id=user_id, **insert_values))
+
+
+async def is_move_opted_out(user_id: str, move_type: str) -> bool:
+    settings = await get_user_settings(user_id)
+    if settings is None:
+        return False
+    if move_type == "manual":
+        return settings.manual_move_opt_out
+    if move_type == "auto":
+        return settings.auto_move_opt_out
+    raise ValueError(f"unknown type?? {move_type}")

--- a/slack_extra/tables.py
+++ b/slack_extra/tables.py
@@ -74,3 +74,11 @@ class MigrationChannel(Table):
     id = Serial(primary_key=True)
     channel_id = Varchar(unique=True)
     config = ForeignKey(references=MigrationConfig)
+
+
+class UserSettings(Table):
+    id = Serial(primary_key=True)
+    user_id = Varchar(length=20, unique=True, index=True)
+    manual_move_opt_out = Boolean(default=False)
+    auto_move_opt_out = Boolean(default=False)
+    created_at = Timestamptz()

--- a/slack_extra/views/__init__.py
+++ b/slack_extra/views/__init__.py
@@ -1,6 +1,7 @@
 from slack_extra.views.configure_anchor import configure_anchor_handler
 from slack_extra.views.create_spoiler import create_spoiler_handler
 from slack_extra.views.edit_move import edit_move_handler
+from slack_extra.views.settings import settings_view_handler
 from slack_extra.views.setup_move import setup_move_handler
 
 
@@ -9,6 +10,7 @@ VIEWS = [
     {"id": "create_spoiler", "handler": create_spoiler_handler},
     {"id": "setup_move", "handler": setup_move_handler},
     {"id": "edit_move", "handler": edit_move_handler},
+    {"id": "settings", "handler": settings_view_handler},
 ]
 
 

--- a/slack_extra/views/settings.py
+++ b/slack_extra/views/settings.py
@@ -1,0 +1,25 @@
+from blockkit import Modal
+from blockkit import Section
+from slack_bolt.async_app import AsyncAck
+
+from slack_extra.preferences import set_move_enabled
+
+
+async def settings_view_handler(ack: AsyncAck, body: dict):
+    user_id = body["user"]["id"]
+    values = body["view"]["state"]["values"]
+    selected_options = values["move_settings"]["move_settings"].get(
+        "selected_options", []
+    )
+    enabled_moves = {option["value"] for option in selected_options}
+
+    await set_move_enabled(user_id, "manual", "manual" in enabled_moves)
+    await set_move_enabled(user_id, "auto", "auto" in enabled_moves)
+
+    view = (
+        Modal()
+        .title("Saved!")
+        .add_block(Section(text="Your preferences have been saved! :D"))
+        .close("Done")
+    ).build()
+    await ack(response_action="update", view=view)


### PR DESCRIPTION
this lovely pull brings you goodies such as

- `/se settings` gives a modal for changing things
- `/se settings move manual on|off`
- `/se settings move auto on|off`
- Manual moves skips users with manual_move_opt_out.
- Auto movings skips users with auto_move_opt_out
- DB migration for the new `user_settings` table

testing?

cant setup a slack bot to test, but tested it against the db with some home brewed scripts and the changes dont affect slack directly so that should not be an issue